### PR TITLE
TRITON-2479 sdcnode version 18 needs newer madvise patch for older platforms

### DIFF
--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -12,22 +12,7 @@
         "gcc": "/opt/local/gcc13/bin/gcc",
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
-        "include_gcc_runtime_libs": true,
-        "build_tag": "gz"
-    },
-    {
-        "// image": "minimal-64-lts 24.4.1",
-        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
-        "comment": "Unmodified, fully-relocatable build suitable for all environments.",
-        "version": "v18.20.6",
-        "patch_files": [
-            "patches/dtrace-binutils241-v18.patch",
-            "patches/v8-madvise.patch"
-        ],
-        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
-        "gcc": "/opt/local/gcc13/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations",
-        "build_tag": "zone64"
+        "include_gcc_runtime_libs": true
     },
     {
         "// image": "minimal-64-lts 24.4.1",
@@ -43,23 +28,7 @@
         "gcc": "/opt/local/gcc13/bin/gcc",
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
-        "include_gcc_runtime_libs": true,
-        "build_tag": "gz"
-    },
-    {
-        "// image": "minimal-64-lts 24.4.1",
-        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
-        "comment": "Modified, fully-relocatable build for agents that require historical behaviour.",
-        "version": "v8.17.0",
-        "patch_files": [
-            "patches/dtrace-binutils241-v8.x.patch",
-            "patches/http-keepAliveTimeout-default-0-v8.x.patch",
-            "patches/tls-reload-certs-v8.x.patch"
-        ],
-        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
-        "gcc": "/opt/local/gcc13/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations",
-        "build_tag": "zone64"
+        "include_gcc_runtime_libs": true
     },
     {
         "// image": "minimal-64-lts 24.4.1",
@@ -76,24 +45,7 @@
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
         "include_gcc_runtime_libs": true,
-        "npm_version": "v6.4.1",
-        "build_tag": "gz"
-    },
-    {
-        "// image": "minimal-64-lts 24.4.1",
-        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
-        "comment": "Modified, fully-relocatable build for agents that require historical behaviour.",
-        "version": "v6.17.1",
-        "patch_files": [
-            "patches/dtrace-binutils241-v8.x.patch",
-            "patches/http-keepAliveTimeout-default-0-v6.17+.patch",
-            "patches/tls-reload-certs-v6.x.patch"
-        ],
-        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
-        "gcc": "/opt/local/gcc7/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations",
-        "npm_version": "v6.4.1",
-        "build_tag": "zone64"
+        "npm_version": "v6.4.1"
     },
     {
         "// image": "minimal-64-lts 21.4.0",

--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -10,7 +10,7 @@
         ],
         "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
         "gcc": "/opt/local/gcc13/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations -D__EXTENSIONS__",
+        "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
         "include_gcc_runtime_libs": true
     },

--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -10,7 +10,7 @@
         ],
         "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
         "gcc": "/opt/local/gcc13/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations",
+        "cflags": "-fno-aggressive-loop-optimizations -D_EXTENSIONS_",
         "rpath": "$ORIGIN/../lib",
         "include_gcc_runtime_libs": true
     },

--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -12,7 +12,22 @@
         "gcc": "/opt/local/gcc13/bin/gcc",
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
-        "include_gcc_runtime_libs": true
+        "include_gcc_runtime_libs": true,
+        "build_tag": "gz"
+    },
+    {
+        "// image": "minimal-64-lts 24.4.1",
+        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
+        "comment": "Unmodified, fully-relocatable build suitable for all environments.",
+        "version": "v18.20.6",
+        "patch_files": [
+            "patches/dtrace-binutils241-v18.patch",
+            "patches/v8-madvise.patch"
+        ],
+        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
+        "gcc": "/opt/local/gcc13/bin/gcc",
+        "cflags": "-fno-aggressive-loop-optimizations",
+        "build_tag": "zone64"
     },
     {
         "// image": "minimal-64-lts 24.4.1",
@@ -28,7 +43,23 @@
         "gcc": "/opt/local/gcc13/bin/gcc",
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
-        "include_gcc_runtime_libs": true
+        "include_gcc_runtime_libs": true,
+        "build_tag": "gz"
+    },
+    {
+        "// image": "minimal-64-lts 24.4.1",
+        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
+        "comment": "Modified, fully-relocatable build for agents that require historical behaviour.",
+        "version": "v8.17.0",
+        "patch_files": [
+            "patches/dtrace-binutils241-v8.x.patch",
+            "patches/http-keepAliveTimeout-default-0-v8.x.patch",
+            "patches/tls-reload-certs-v8.x.patch"
+        ],
+        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
+        "gcc": "/opt/local/gcc13/bin/gcc",
+        "cflags": "-fno-aggressive-loop-optimizations",
+        "build_tag": "zone64"
     },
     {
         "// image": "minimal-64-lts 24.4.1",
@@ -45,7 +76,24 @@
         "cflags": "-fno-aggressive-loop-optimizations",
         "rpath": "$ORIGIN/../lib",
         "include_gcc_runtime_libs": true,
-        "npm_version": "v6.4.1"
+        "npm_version": "v6.4.1",
+        "build_tag": "gz"
+    },
+    {
+        "// image": "minimal-64-lts 24.4.1",
+        "image": "41bd4100-eb86-409a-85b0-e649aadf6f62",
+        "comment": "Modified, fully-relocatable build for agents that require historical behaviour.",
+        "version": "v6.17.1",
+        "patch_files": [
+            "patches/dtrace-binutils241-v8.x.patch",
+            "patches/http-keepAliveTimeout-default-0-v6.17+.patch",
+            "patches/tls-reload-certs-v6.x.patch"
+        ],
+        "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
+        "gcc": "/opt/local/gcc7/bin/gcc",
+        "cflags": "-fno-aggressive-loop-optimizations",
+        "npm_version": "v6.4.1",
+        "build_tag": "zone64"
     },
     {
         "// image": "minimal-64-lts 21.4.0",

--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -10,7 +10,7 @@
         ],
         "configure_flags": "--without-snapshot --dest-cpu=x64 --with-dtrace",
         "gcc": "/opt/local/gcc13/bin/gcc",
-        "cflags": "-fno-aggressive-loop-optimizations -D_EXTENSIONS_",
+        "cflags": "-fno-aggressive-loop-optimizations -D__EXTENSIONS__",
         "rpath": "$ORIGIN/../lib",
         "include_gcc_runtime_libs": true
     },

--- a/patches/v8-madvise.patch
+++ b/patches/v8-madvise.patch
@@ -1,24 +1,38 @@
-The madvise() prototype changed in https://www.illumos.org/issues/14418 but we
-want to retain the ability to build on platforms both before and after the
-change.  Hardcoding one version of the prototype here is completely pointless,
-so just remove and use whatever the build host provides.
+From e1f935dbb3fc08ab45986f03d249dc1b85420086 Mon Sep 17 00:00:00 2001
+From: Dan McDonald <danmcd@mnx.io>
+Date: Mon, 7 Apr 2025 10:51:23 -0400
+Subject: [PATCH] deps: illumos madvise() pre-and-post-illumos#14418
+
+In illumos, madvise(3C) now takes `void *` for its first argument
+post-illumos#14418, but uses `caddr_t` pre-illumos#14418. This fix
+will detect if the illumos is pre-or-post-illumos#14418 so builds can
+work either way.
+---
+ deps/v8/src/base/platform/platform-posix.cc | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/deps/v8/src/base/platform/platform-posix.cc b/deps/v8/src/base/platform/platform-posix.cc
-index 517cbfccab..588830d062 100644
+index 2d351f67b93bdb..5c93b3aaafe34a 100644
 --- a/deps/v8/src/base/platform/platform-posix.cc
 +++ b/deps/v8/src/base/platform/platform-posix.cc
-@@ -72,14 +72,6 @@
+@@ -80,7 +80,19 @@
  #define MAP_ANONYMOUS MAP_ANON
  #endif
  
 -#if defined(V8_OS_SOLARIS)
--#if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE > 2) || defined(__EXTENSIONS__)
--extern "C" int madvise(caddr_t, size_t, int);
--#else
--extern int madvise(caddr_t, size_t, int);
--#endif
--#endif
--
- #ifndef MADV_FREE
- #define MADV_FREE MADV_DONTNEED
- #endif
++/*
++ * NOTE: illumos starting with illumos#14418 (pushed April 20th, 2022)
++ * prototypes madvise(3C) properly with a `void *` first argument.
++ * The only way to detect this outside of configure-time checking is to
++ * check for the existence of MEMCNTL_SHARED, which gets defined for the first
++ * time in illumos#14418 under the same circumstances save _STRICT_POSIX, which
++ * thankfully neither Solaris nor illumos builds of Node or V8 do.
++ *
++ * If some future illumos push changes the MEMCNTL_SHARED assumptions made
++ * above, the illumos check below will have to be revisited.  This check
++ * will work on both pre-and-post illumos#14418 illumos environments.
++ */
++#if defined(V8_OS_SOLARIS) && !(defined(__illumos__) && defined(MEMCNTL_SHARED))
+ #if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE > 2) || defined(__EXTENSIONS__)
+ extern "C" int madvise(caddr_t, size_t, int);
+ #else

--- a/tools/build-a-node
+++ b/tools/build-a-node
@@ -18,7 +18,7 @@
 #   ./tools/build-a-node BUILD-OPTS BUILD-DIR BUILD-STAMP
 #
 # Example:
-#   ./tools/build-a-node '{"version": "v0.8.23}' \
+#   ./tools/build-a-node '{"version": "v0.8.23"}' \
 #       `pwd`/build/nodes/v0.8.23-zone \
 #       master-20130913T173257Z-gfb34f86
 #


### PR DESCRIPTION
sdcnode version 18.20.6 build on minimal-64-lts 24.4.1 currently fails with 

```
../deps/v8/src/base/platform/platform-posix.cc: In static member function 'static bool v8::base::OS::DiscardSystemPages(void*, std::size_t)':
../deps/v8/src/base/platform/platform-posix.cc:517:13: error: 'madvise' was not declared in this scope
517 |   int ret = madvise(reinterpret_cast<caddr_t>(address), size, MADV_FREE);
    |             ^~~~~~~
make[2]: *** [tools/v8_gypfiles/v8_libbase.target.mk:175: 
/root/data/jenkins/workspace/TritonDataCenter_sdcnode_master/build/nodes/v18.20.6/
src/out/Release/obj.target/v8_libbase/deps/v8/src/base/platform/platform-posix.o] Error 1
```

